### PR TITLE
Fix spacer component on Outlook and Windows Mail clients

### DIFF
--- a/lib/inky/component_factory.rb
+++ b/lib/inky/component_factory.rb
@@ -121,7 +121,7 @@ module Inky
 
     def _transform_spacer(component, _inner)
       classes = _combine_classes(component, 'spacer')
-      build_table = ->(size, extra) { %{<table class="#{classes} #{extra}"><tbody><tr><td height="#{size}px" style="font-size:#{size}px;line-height:#{size}px;">&#xA0;</td></tr></tbody></table>} }
+      build_table = ->(size, extra) { %{<table class="#{classes} #{extra}"><tbody><tr><td height="#{size}" style="font-size:#{size}px;line-height:#{size}px;">&#xA0;</td></tr></tbody></table>} }
       size = component.attr('size')
       size_sm = component.attr('size-sm')
       size_lg = component.attr('size-lg')

--- a/spec/components_spec.rb
+++ b/spec/components_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe "Spacer" do
       <table class="spacer">
         <tbody>
           <tr>
-            <td height="10px" style="font-size:10px;line-height:10px;">&#xA0;</td>
+            <td height="10" style="font-size:10px;line-height:10px;">&#xA0;</td>
           </tr>
         </tbody>
       </table>
@@ -274,7 +274,7 @@ RSpec.describe "Spacer" do
       <table class="spacer hide-for-large">
         <tbody>
           <tr>
-            <td height="10px" style="font-size:10px;line-height:10px;">&#xA0;</td>
+            <td height="10" style="font-size:10px;line-height:10px;">&#xA0;</td>
           </tr>
         </tbody>
       </table>
@@ -289,7 +289,7 @@ RSpec.describe "Spacer" do
       <table class="spacer show-for-large">
         <tbody>
           <tr>
-            <td height="20px" style="font-size:20px;line-height:20px;">&#xA0;</td>
+            <td height="20" style="font-size:20px;line-height:20px;">&#xA0;</td>
           </tr>
         </tbody>
       </table>
@@ -304,14 +304,14 @@ RSpec.describe "Spacer" do
         <table class="spacer hide-for-large">
           <tbody>
             <tr>
-              <td height="10px" style="font-size:10px;line-height:10px;">&#xA0;</td>
+              <td height="10" style="font-size:10px;line-height:10px;">&#xA0;</td>
             </tr>
           </tbody>
         </table>
         <table class="spacer show-for-large">
           <tbody>
             <tr>
-              <td height="20px" style="font-size:20px;line-height:20px;">&#xA0;</td>
+              <td height="20" style="font-size:20px;line-height:20px;">&#xA0;</td>
             </tr>
           </tbody>
         </table>
@@ -326,7 +326,7 @@ RSpec.describe "Spacer" do
       <table class="spacer bgcolor">
         <tbody>
           <tr>
-            <td height="10px" style="font-size:10px;line-height:10px;">&#xA0;</td>
+            <td height="10" style="font-size:10px;line-height:10px;">&#xA0;</td>
           </tr>
         </tbody>
       </table>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,9 @@ def reformat_html(html)
       classes = $1.split(' ').sort.join(' ')
       %{class="#{classes}"}
     end
+    .gsub(/<td height=".+?px"/) do |m|                # Tweak out px until https://github.com/zurb/inky/pull/106 resolved
+      m.gsub('px', '')
+    end
 end
 
 def expect_same_html(input, expected)


### PR DESCRIPTION
As discussed [here](https://github.com/zurb/foundation-emails/issues/725), [here](https://github.com/zurb/inky/issues/104), and [here](https://foundation.zurb.com/forum/posts/47983-outlook-2010-spacer-issue) `spacer` components do not render on several Outlook clients and some versions of Windows Mail.

The community's suggested fix is to remove the unit from the`td` `height` attribute like so. In my testing this resolves the issue on these clients and doesn't cause a regression in others.