### PR TITLE
Use children instead of elements

### DIFF
--- a/lib/inky/component_factory.rb
+++ b/lib/inky/component_factory.rb
@@ -93,7 +93,7 @@ module Inky
       classes << ' first' unless component.previous_element
       classes << ' last' unless component.next_element
 
-      subrows = component.elements.css(".row").to_a.concat(component.elements.css("row").to_a)
+      subrows = component.children.css(".row").to_a.concat(component.children.css("row").to_a)
       expander = %{<th class="expander"></th>} if large_size.to_i == column_count && subrows.empty?
 
       %{<#{INTERIM_TH_TAG} class="#{classes}" #{_pass_through_attributes(component)}><table><tr><th>#{inner}</th>#{expander}</tr></table></#{INTERIM_TH_TAG}>}
@@ -107,10 +107,10 @@ module Inky
     def _transform_center(component, _inner)
       # NOTE:  Using children instead of elements because elements.to_a
       # sometimes appears to miss elements that show up in size
-      component.elements.each do |child|
+      component.children.each do |child|
         child['align'] = 'center'
         child['class'] = _combine_classes(child, 'float-center')
-        items = component.elements.css(".menu-item").to_a.concat(component.elements.css("item").to_a)
+        items = component.children.css(".menu-item").to_a.concat(component.children.css("item").to_a)
         items.each do |item|
           item['class'] = _combine_classes(item, 'float-center')
         end


### PR DESCRIPTION
Nokogiri, when run with JRuby, doesn't seem to like having `css` called on its elements, if they are missing (empty).

```
ActionView::Template::Error:
       undefined method `root' for nil:NilClass
     # /Users/ohm/.rbenv/versions/jruby-9.2.5.0/lib/ruby/gems/shared/gems/nokogiri-1.9.1-java/lib/nokogiri/xml/searchable.rb:224:in `extract_params'
     # /Users/ohm/.rbenv/versions/jruby-9.2.5.0/lib/ruby/gems/shared/gems/nokogiri-1.9.1-java/lib/nokogiri/xml/node_set.rb:80:in `css'
     # /Users/ohm/.rbenv/versions/jruby-9.2.5.0/lib/ruby/gems/shared/gems/inky-rb-1.3.7.5/lib/inky/component_factory.rb:97:in `_transform_columns'
     # /Users/ohm/.rbenv/versions/jruby-9.2.5.0/lib/ruby/gems/shared/gems/inky-rb-1.3.7.5/lib/inky/component_factory.rb:8:in `component_factory'
     # /Users/ohm/.rbenv/versions/jruby-9.2.5.0/lib/ruby/gems/shared/gems/inky-rb-1.3.7.5/lib/inky.rb:54:in `transform_doc'
     # /Users/ohm/.rbenv/versions/jruby-9.2.5.0/lib/ruby/gems/shared/gems/inky-rb-1.3.7.5/lib/inky.rb:52:in `block in transform_doc'
     # /Users/ohm/.rbenv/versions/jruby-9.2.5.0/lib/ruby/gems/shared/gems/nokogiri-1.9.1-java/lib/nokogiri/xml/node_set.rb:204:in `block in each'
     # org/jruby/RubyInteger.java:206:in `upto'
     # /Users/ohm/.rbenv/versions/jruby-9.2.5.0/lib/ruby/gems/shared/gems/nokogiri-1.9.1-java/lib/nokogiri/xml/node_set.rb:203:in `each'
     # /Users/ohm/.rbenv/versions/jruby-9.2.5.0/lib/ruby/gems/shared/gems/inky-rb-1.3.7.5/lib/inky.rb:51:in `transform_doc'
     # /Users/ohm/.rbenv/versions/jruby-9.2.5.0/lib/ruby/gems/shared/gems/inky-rb-1.3.7.5/lib/inky.rb:52:in `block in transform_doc'
     # /Users/ohm/.rbenv/versions/jruby-9.2.5.0/lib/ruby/gems/shared/gems/nokogiri-1.9.1-java/lib/nokogiri/xml/node_set.rb:204:in `block in each'
     # org/jruby/RubyInteger.java:206:in `upto'
     # /Users/ohm/.rbenv/versions/jruby-9.2.5.0/lib/ruby/gems/shared/gems/nokogiri-1.9.1-java/lib/nokogiri/xml/node_set.rb:203:in `each'
     # /Users/ohm/.rbenv/versions/jruby-9.2.5.0/lib/ruby/gems/shared/gems/inky-rb-1.3.7.5/lib/inky.rb:51:in `transform_doc'
     # /Users/ohm/.rbenv/versions/jruby-9.2.5.0/lib/ruby/gems/shared/gems/inky-rb-1.3.7.5/lib/inky.rb:52:in `block in transform_doc'
     # /Users/ohm/.rbenv/versions/jruby-9.2.5.0/lib/ruby/gems/shared/gems/nokogiri-1.9.1-java/lib/nokogiri/xml/node_set.rb:204:in `block in each'
     # org/jruby/RubyInteger.java:206:in `upto'
     # /Users/ohm/.rbenv/versions/jruby-9.2.5.0/lib/ruby/gems/shared/gems/nokogiri-1.9.1-java/lib/nokogiri/xml/node_set.rb:203:in `each'
     # /Users/ohm/.rbenv/versions/jruby-9.2.5.0/lib/ruby/gems/shared/gems/inky-rb-1.3.7.5/lib/inky.rb:51:in `transform_doc'
     # /Users/ohm/.rbenv/versions/jruby-9.2.5.0/lib/ruby/gems/shared/gems/inky-rb-1.3.7.5/lib/inky.rb:43:in `release_the_kraken'
```

As this comment 

https://github.com/zurb/inky-rb/blob/208ade8b9fa95afae0e81b8cd0bb23ab96371e5b/lib/inky/component_factory.rb#L108-L109

already states that `elements` work differently than `children` (even though `children` isn't used here) I believe all of these should just be replaced with `children`.